### PR TITLE
Feat/chat storage

### DIFF
--- a/src/pages/chat.page.ts
+++ b/src/pages/chat.page.ts
@@ -1,6 +1,7 @@
-import {BaseElement, BindEvent, Component} from "@ayu-sh-kr/dota-core";
+import {AfterInit, BaseElement, BindEvent, Component} from "@ayu-sh-kr/dota-core";
 import {OpenAIService} from "@dota/service/OpenAIService.ts";
 import {MessageBoxComponent} from "@dota/components/chat";
+import {LocalStorageService} from "@dota/service/local-storage.service.ts";
 
 @Component({
   selector: "chat-page",
@@ -15,11 +16,22 @@ export class ChatPage extends BaseElement {
   constructor() {
     super();
     this.openApiService = new OpenAIService("deepseek/deepseek-r1-distill-llama-8b")
+    this.messages = []
+  }
+
+  @AfterInit()
+  afterViewInit() {
+    this.messages = LocalStorageService.getList<MessageRecord>("message");
+    this.updateMessageBox();
   }
 
   @BindEvent({event: 'onMessageEvent', id: '#ai-form'})
   listenUserMessage(event: CustomEvent<MessageRecord>) {
-    this.messages.push(event.detail)
+    this.messages = LocalStorageService.pushToList<MessageRecord>("message", event.detail);
+    this.updateMessageBox();
+  }
+
+  private updateMessageBox() {
     const messageBox = this.querySelector<MessageBoxComponent>("#message-box");
     if (messageBox) {
       messageBox.messages = this.messages;

--- a/src/service/local-storage.service.ts
+++ b/src/service/local-storage.service.ts
@@ -1,0 +1,57 @@
+
+
+export class LocalStorageService {
+
+  static get(key: string): string | null {
+    return localStorage.getItem(key);
+  }
+
+  static add(key: string, value: string): void {
+    localStorage.setItem(key, value);
+  }
+
+
+  /**
+   * Stores a list at the specified key
+   */
+  static addList<T>(key: string, list: T[]): void {
+    localStorage.setItem(key, JSON.stringify(list));
+  }
+
+  /**
+   * Retrieves a list from the specified key
+   */
+  static getList<T>(key: string): T[] {
+    const storedValue = localStorage.getItem(key);
+    if (!storedValue) return [];
+    try {
+      return JSON.parse(storedValue) as T[];
+    } catch (e) {
+      console.error(`Failed to parse list from localStorage key: ${key}`);
+      return [];
+    }
+  }
+
+  /**
+   * Adds an item to the end of a list at the specified key
+   */
+  static pushToList<T>(key: string, item: T): T[] {
+    const list = this.getList<T>(key);
+    list.push(item);
+    this.addList(key, list);
+    return list;
+  }
+
+  /**
+   * Removes and returns the last item from a list at the specified key
+   */
+  static popFromList<T>(key: string): T | undefined {
+    const list = this.getList<T>(key);
+    if (list.length === 0) return undefined;
+
+    const item = list.pop();
+    this.addList(key, list);
+    return item;
+  }
+
+}


### PR DESCRIPTION
This pull request introduces significant enhancements to the chat page functionality by integrating local storage capabilities. The major changes include importing the `AfterInit` lifecycle hook, initializing messages from local storage, and updating the message handling to use the new `LocalStorageService`.

### Enhancements to chat page functionality:

* [`src/pages/chat.page.ts`](diffhunk://#diff-1aae1cd62678f9875777e5a2c67ef6943e2c4d4969e3af755dab571390f0e331L1-R4): Imported `AfterInit` and `LocalStorageService`, initialized messages from local storage in `afterViewInit`, and updated message handling to use `LocalStorageService` for storing and retrieving messages. [[1]](diffhunk://#diff-1aae1cd62678f9875777e5a2c67ef6943e2c4d4969e3af755dab571390f0e331L1-R4) [[2]](diffhunk://#diff-1aae1cd62678f9875777e5a2c67ef6943e2c4d4969e3af755dab571390f0e331R19-R34)

### Addition of LocalStorageService:

* [`src/service/local-storage.service.ts`](diffhunk://#diff-66edca820dda3601afbd82f2ec0861afc8273d5aebd25ea1cc8f36f2b957e467R1-R57): Added a new `LocalStorageService` class with methods to store, retrieve, and manipulate lists in local storage, including `getList`, `addList`, `pushToList`, and `popFromList`.