### PR TITLE
Fix/dark mode btn

### DIFF
--- a/src/components/utils/buttons/dark-mode-button.component.ts
+++ b/src/components/utils/buttons/dark-mode-button.component.ts
@@ -1,8 +1,5 @@
-import {BaseElement, Component} from "@ayu-sh-kr/dota-core/dist";
-import {AfterInit, BindEvent} from "@ayu-sh-kr/dota-core";
-
-import {GeneralUtils, toggleDark} from "@dota/utils/GeneralUtils.ts";
-import {LocalStorageService} from "@dota/service/local-storage.service.ts";
+import {BaseElement, Component, BindEvent, WindowListener} from "@ayu-sh-kr/dota-core";
+import {GeneralUtils} from "@dota/utils/GeneralUtils.ts";
 
 
 @Component({
@@ -15,41 +12,23 @@ export class DarkModeButtonComponent extends BaseElement {
     super();
   }
 
-  @AfterInit()
-  afterViewInit() {
-    const browserTheme = GeneralUtils.getBrowserTheme();
-    switch (browserTheme) {
-      case 'dark':
-        this.querySelector('#dark-button')!.innerHTML = `<dota-icon name="material-symbols:dark-mode" color="purple" variant="ghost" size="md" />`;
-        break;
-      case 'light':
-        this.querySelector('#dark-button')!.innerHTML = `<dota-icon name="material-symbols:sunny-rounded" color="purple" variant="ghost" size="md" />`;
-        break;
-      default:
-        break;
-    }
-  }
-
   @BindEvent({event: 'click', id: '#dark-button'})
   handleDark() {
-    const iconContainer = this.querySelector('#dark-button');
+    GeneralUtils.toggleDarkMode();
+  }
 
-    if (iconContainer) {
-      if (toggleDark()) {
-        iconContainer.innerHTML = `<dota-icon  name="material-symbols:dark-mode" color="purple" variant="ghost" size="md" />`
-        LocalStorageService.add('theme', 'dark');
-      } else {
-        iconContainer.innerHTML = `<dota-icon  name="material-symbols:sunny-rounded" color="purple" variant="ghost" size="md" />`
-        LocalStorageService.add('theme', 'light');
-      }
-    }
+  @WindowListener({event: 'themeChange'})
+  handleThemeChange() {
+    this.updateHTML();
   }
 
   render(): string {
+    const isDarkTheme = GeneralUtils.isDarkMode();
+    const icon = isDarkTheme ? 'material-symbols:dark-mode' : 'material-symbols:sunny-rounded';
     // language=html
     return `
       <span id="dark-button" class="active:scale-95 cursor-pointer">
-        <dota-icon name="material-symbols:sunny-rounded" color="purple" variant="ghost" size="md"/>
+        <dota-icon name="${icon}" color="purple" variant="ghost" size="md"/>
       </span>
     `;
   }

--- a/src/utils/GeneralUtils.ts
+++ b/src/utils/GeneralUtils.ts
@@ -12,6 +12,13 @@ export class GeneralUtils {
     const isDarkMode = document.documentElement.classList.toggle('dark');
     document.documentElement.classList.toggle('bg-slate-950', isDarkMode);
     LocalStorageService.add('theme', isDarkMode ? 'dark' : 'light');
+    window.dispatchEvent(new CustomEvent('themeChange', {
+      detail: { isDarkMode: GeneralUtils.isDarkMode() }
+    }))
+  }
+
+  static isDarkMode() {
+    return document.documentElement.classList.contains('dark');
   }
 
   static getBrowserTheme() {


### PR DESCRIPTION
This pull request refactors the `DarkModeButtonComponent` to simplify its logic, improve maintainability, and enhance responsiveness to theme changes. The changes include removing redundant code, centralizing theme-related logic in `GeneralUtils`, and introducing a new `themeChange` event for dynamic updates.

### Refactoring and simplification:

* [`src/components/utils/buttons/dark-mode-button.component.ts`](diffhunk://#diff-4be53fe03622df23834a101960b198441dbe71b410923cdedec01b067d931ae6L18-R31): Removed the `afterViewInit` method and redundant theme-switching logic from `handleDark`. Theme toggling is now handled by the centralized `GeneralUtils.toggleDarkMode()` method.

* [`src/utils/GeneralUtils.ts`](diffhunk://#diff-0f4a6e5f58a129abba9336a8eed6790dedef3c7e2e3669c4df1738acc41d8614R15-R21): Added a new `isDarkMode` method to check the current theme and refactored `toggleDarkMode` to dispatch a `themeChange` event whenever the theme is toggled.

### Dynamic theme updates:

* [`src/components/utils/buttons/dark-mode-button.component.ts`](diffhunk://#diff-4be53fe03622df23834a101960b198441dbe71b410923cdedec01b067d931ae6L18-R31): Introduced a `@WindowListener` for the `themeChange` event, enabling the component to dynamically update its HTML based on the current theme.

### Code cleanup:

* [`src/components/utils/buttons/dark-mode-button.component.ts`](diffhunk://#diff-4be53fe03622df23834a101960b198441dbe71b410923cdedec01b067d931ae6L1-R2): Removed unused imports (`AfterInit`, `toggleDark`, and `LocalStorageService`) and added `WindowListener` to the imports for handling the new event.