### PR TITLE
fix: update import for route utility in doc-path.component.ts

### DIFF
--- a/src/components/docs/doc-path.component.ts
+++ b/src/components/docs/doc-path.component.ts
@@ -1,6 +1,6 @@
 import { BaseElement, Component, HostListener, Property, String } from "@ayu-sh-kr/dota-core";
-import { RouteUtils } from "@dota/utils/RouteUtils.ts";
 import {routerService} from "@dota/configs/routes.config.ts";
+import {RouterUtils} from "@ayu-sh-kr/dota-router";
 
 @Component({
   selector: "doc-path",
@@ -23,7 +23,7 @@ export class DocPathComponent extends BaseElement {
   }
 
   render(): string {
-    const includes = RouteUtils.getCurrentEntry().includes(this.filePath);
+    const includes = RouterUtils.getCurrentPath().includes(this.filePath);
     // language=html
     return `
     <div class="cursor-pointer text-sm text-[#67676c] dark:text-gray-300 py-2 px-2 transition-all hover:text-purple-500 duration-300 ease-in-out font-medium ${


### PR DESCRIPTION
This pull request updates the `DocPathComponent` to use a different utility module for routing functionality. The changes involve replacing the import and usage of `RouteUtils` with `RouterUtils`.

### Updates to routing utilities:

* [`src/components/docs/doc-path.component.ts`](diffhunk://#diff-6bd9963184f8ec4560cec70781a837f79edc9bae5fbcfa61031306b566e2c27aL2-R3): Replaced the import of `RouteUtils` from `@dota/utils/RouteUtils.ts` with `RouterUtils` from `@ayu-sh-kr/dota-router`.
* [`src/components/docs/doc-path.component.ts`](diffhunk://#diff-6bd9963184f8ec4560cec70781a837f79edc9bae5fbcfa61031306b566e2c27aL26-R26): Updated the `render` method to use `RouterUtils.getCurrentPath()` instead of `RouteUtils.getCurrentEntry()`.