### PR TITLE
fix: update header link to point to the root path for improved navigation

### DIFF
--- a/src/components/utils/header/header.component.ts
+++ b/src/components/utils/header/header.component.ts
@@ -37,17 +37,17 @@ export class HeaderComponent extends BaseElement {
                 <nav class="flex py-3 justify-between items-center shadow-sm backdrop-blur-lg backdrop-brightness-125 dark:backdrop-brightness-110 
                     dark:shadow-purple-400 max-w-5xl rounded-full mx-auto">
                      <div class="font-extrabold text-2xl w-1/6 px-5 text-gray-900 dark:text-gray-100">
-                        <a href="/public">Dota</a>
+                        <a href="/">Dota</a>
                      </div>
                     <div class="md:flex justify-center items-center hidden w-4/6">
                         <ul class="flex justify-between items-center gap-x-5 w-1/2">
                                 ${this.items.map((item) => {
-        return `
+                                    return `
                                              <li class="text-sm font-semibold hover:text-purple-600 dark:hover:text-purple-500 text-gray-700 dark:text-gray-100">
                                                 <a href="${item.url}">${item.name}</a>
                                              </li>
                                     `;
-    }).join("")}
+                                }).join("")}
                          </ul>
                       </div>
                       <div class="flex items-center px-5 gap-x-3 justify-end">


### PR DESCRIPTION
This pull request includes a minor update to the `HeaderComponent` in the `src/components/utils/header/header.component.ts` file. The change updates the navigation link for the logo.

* Updated the logo link in the header navigation from `/public` to `/`, ensuring the logo redirects to the homepage. (`[src/components/utils/header/header.component.tsL40-R40](diffhunk://#diff-d58e3d34744e21c0896331fd6b99cd90929922efd92ed65429a3ffe29b3e684cL40-R40)`)