### PR TITLE
Chores/fixes

### DIFF
--- a/src/components/docs/doc-section.component.ts
+++ b/src/components/docs/doc-section.component.ts
@@ -29,7 +29,7 @@ export class DocSectionComponent extends BaseElement {
   render(): string {
     // language=html
     return `
-      <section class="flex gap-4 relative font-dm w-full">
+      <section class="flex gap-4 relative font-dm w-full mt-10">
         <aside class="sticky top-14 h-[calc(100vh-50px)] hidden md:block w-64 bg-[#F6F6F7]  dark:bg-gray-900 overflow-y-auto text-sm space-y-4 border-r custom-scrollbar px-4">
           <h1 class="text-2xl font-bold border-b dark:!bg-transparent dark:text-white sticky top-0  py-4 pl-4 w-full bg-[#F6F6F7]"> Dota <span class="text-purple-600">Docs</span></h1>
           ${docConfigs

--- a/src/components/home/utils/get-started-button.component.ts
+++ b/src/components/home/utils/get-started-button.component.ts
@@ -14,7 +14,7 @@ export class GetStartedButtonComponent extends BaseElement {
 
   @HostListener({event: 'click'})
   onClickListener() {
-    routerService.route('/docs/getting-started');
+    routerService.route("/docs/Getting-Started.md");
   }
 
   render(): string {

--- a/src/pages/error.page.ts
+++ b/src/pages/error.page.ts
@@ -44,10 +44,8 @@ export class ErrorPage extends BaseElement {
             <dota-icon name="mdi:home" variant="ghost" size="md"></dota-icon>
             Go Home
           </a>
-          <source src="https://cdnl.iconscout.com/lottie/premium/preview-watermark/error-404-14393877-11613454.mp4"
-                  type="video/mp4">
 
-          <a href="/docs"
+          <a href="/docs/Getting-Started.md"
              class="bg-gray-200 dark:bg-slate-800 dark:text-white px-5 py-3 rounded-lg flex items-center gap-1">
             <svg xmlns="http://www.w3.org/2000/svg" width="32" height="24" viewBox="0 0 24 24">
               <path fill="currentColor"


### PR DESCRIPTION
This pull request includes updates to the `docs` section styling, fixes a routing issue for the "Get Started" button, and adjusts the error page links. Below is a summary of the most important changes:

### Styling Update:
* Added a top margin (`mt-10`) to the `<section>` element in the `DocSectionComponent` to improve spacing in the layout. (`src/components/docs/doc-section.component.ts`)

### Routing Fixes:
* Updated the "Get Started" button routing to point to the correct file (`/docs/Getting-Started.md`) instead of `/docs/getting-started`. (`src/components/home/utils/get-started-button.component.ts`)
* Adjusted the error page link to redirect to `/docs/Getting-Started.md` instead of `/docs` for better accuracy. (`src/pages/error.page.ts`)